### PR TITLE
Fix missing include in overmap.cpp

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -41,6 +41,7 @@
 #include <cstring>
 #include <ostream>
 #include <algorithm>
+#include <numeric>
 
 #define dbg(x) DebugLog((DebugLevel)(x),D_MAP_GEN) << __FILE__ << ":" << __LINE__ << ": "
 


### PR DESCRIPTION
This fixes a build error on some systems caused by missing

 #include <numeric>

in src/overmap.cpp